### PR TITLE
DX: Typescript [Key Registery]

### DIFF
--- a/src/Hooks/usePicker.tsx
+++ b/src/Hooks/usePicker.tsx
@@ -1,24 +1,30 @@
-"use client"
+"use client";
+
 import { useEffect, useState, useRef } from 'react';
 import { globalStore, ServerStore } from '../core-utils/createServerStore';
 import { getSharedState } from '../core-utils/sharedState';
 import pubsub from '../core/pubsub';
+import { KeyRegistry } from '../core-utils/keyRegistery';
 
 interface PickerOptions<T> {
   store?: ServerStore;
 }
-export function usePicker<T, S>(
-  key: string,
-  selector: (state: T) => S,
+
+export function usePicker<K extends keyof KeyRegistry, S>(
+  key: K,
+  selector: (state: KeyRegistry[K]) => S,
   equalityFn: (a: S, b: S) => boolean = (a, b) => a === b,
-  options?: PickerOptions<T>
+  options?: PickerOptions<KeyRegistry[K]>
 ): S {
   const store = options?.store || globalStore;
-  const [selected, setSelected] = useState(() => selector(getSharedState<T>(key, store)));
+
+  const [selected, setSelected] = useState(() =>
+    selector(getSharedState<KeyRegistry[K]>(key as string, store))
+  );
   const latestSelected = useRef(selected);
 
   useEffect(() => {
-    const update = (newValue: T) => {
+    const update = (newValue: KeyRegistry[K]) => {
       const nextSelected = selector(newValue);
       if (!equalityFn(latestSelected.current, nextSelected)) {
         latestSelected.current = nextSelected;
@@ -26,9 +32,9 @@ export function usePicker<T, S>(
       }
     };
 
-    pubsub.subscribe<T>(key, update);
-    return () => pubsub.unsubscribe<T>(key, update);
-  }, [key, selector, equalityFn]);
+    pubsub.subscribe<KeyRegistry[K]>(key as string, update);
+    return () => pubsub.unsubscribe<KeyRegistry[K]>(key as string, update);
+  }, [key, selector, equalityFn, store]);
 
   return selected;
 }

--- a/src/core-utils/createServerStore.ts
+++ b/src/core-utils/createServerStore.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 export interface ServerStore {
     get: <T>(key: string) => T;

--- a/src/core-utils/keyRegistery.ts
+++ b/src/core-utils/keyRegistery.ts
@@ -1,0 +1,3 @@
+export interface KeyRegistry {
+    
+}

--- a/src/core-utils/sharedState.ts
+++ b/src/core-utils/sharedState.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { produce } from 'immer';
 import pubsub from '../core/pubsub';
 import { runMiddlewares } from './Middleware';
@@ -5,11 +6,12 @@ import { globalStore, ServerStore } from './createServerStore';
 import { persistValue, getPersistedValue, setPersistence } from './persistance';
 
 
-export function createSharedState<T>(key: string, initialValue: T, options?: {store?: ServerStore, persist?: "localStorage" | "sessionStorage" }) {
+export function createSharedState<T>(key: string, initialValue: T, options?: {store?: ServerStore, persist?: "localStorage" | "sessionStorage"}) {
   let store = options?.store;
   if(!store) store = globalStore
   if(options?.persist) setPersistence(key, options?.persist);
   const persisted = getPersistedValue<T>(key);
+  // eslint-disable-next-line no-prototype-builtins
   if (!store.getSnapshot().hasOwnProperty(key)) {
     store.set(key,  persisted !== undefined ? persisted : initialValue);
   }


### PR DESCRIPTION
DX: Typescript [Key Registery]

Added support for KeyRegistery

Tasks

- Refactor useSharedState to infer type based on the key
- Refactor usePicker to infer state type based on the key